### PR TITLE
Install dnsutils for the nslookup tool that is needed for the DNS check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,6 @@ RUN opam pin -n add genspio https://github.com/hammerlab/genspio.git
 RUN opam pin -n add secotrec https://github.com/hammerlab/secotrec.git
 RUN opam upgrade
 RUN opam install tls secotrec biokepi
+
+# This is needed for the DNS check happening as part of `secotrec-gke up`:
+RUN sudo apt-get install -y dnsutils


### PR DESCRIPTION
Otherwise, `secotrec-gke up` fails at `SECOTREC: DNS...` when run inside the docker image.