### PR TITLE
Add support for b37 data preparation to local/gke apps

### DIFF
--- a/src/app/example_gke.ml
+++ b/src/app/example_gke.ml
@@ -177,6 +177,9 @@ let example_1 () =
       download
         "https://storage.googleapis.com/hammerlab-biokepi-data/precomputed/b37decoy_20160927.tgz"
         ~in_directory:(leading_extra_nfs // "workdir/reference-genome");
+      download
+        "https://storage.googleapis.com/hammerlab-biokepi-data/precomputed/b37_20161007.tgz"
+        ~in_directory:(leading_extra_nfs // "workdir/reference-genome");
     ] in
   Deployment.make "Ex-almost-full"
     ~node:(Deployment.Node.gcloud node)

--- a/src/app/example_local.ml
+++ b/src/app/example_local.ml
@@ -102,6 +102,9 @@ let example () =
       download
         "https://storage.googleapis.com/hammerlab-biokepi-data/precomputed/b37decoy_20160927.tgz"
         ~in_directory:(biokepi_work#mount // "workdir/reference-genome");
+      download
+        "https://storage.googleapis.com/hammerlab-biokepi-data/precomputed/b37_20161007.tgz"
+        ~in_directory:(leading_extra_nfs // "workdir/reference-genome");
     ] in
   Deployment.make "Light-local" ~node
     ?tlstunnel


### PR DESCRIPTION
For those of us who uses the `b37` instead of `b37decoy`.