### PR TITLE
New hammerlab/keredofi:coclobas-gke-biokepi-default docker-image

### DIFF
--- a/opam
+++ b/opam
@@ -29,6 +29,7 @@ depends: [
   "coclobas"
   "ketrew"
   "dockerfile"
+  "ppx_deriving_cmdliner"
 ]
 available: [
   ocaml-version >= "4.03.0"

--- a/src/app/make_dockerfiles.ml
+++ b/src/app/make_dockerfiles.ml
@@ -329,7 +329,8 @@ module Image = struct
                        ~coclobas:(`Version "0.0.1") ())
         ~tests:[
           Test.test_dashdashversion "ketrew" "3.0.0+dev";
-          Test.test_dashdashversion "coclobas" "0.0.1";
+          Test.test_dashdashversion "coclobas" "0.0.0";
+          Test.succeeds "ocamlfind list | grep coclobas | grep 0.0.1";
         ];
       make "coclobas-gke-biokepi-dev"
         ~description:"Image similar to `coclobas-gke-biokepi-default` but \
@@ -340,7 +341,8 @@ module Image = struct
                        ~coclobas:(`Branch "master") ())
         ~tests:[
           Test.test_dashdashversion "ketrew" "3.0.0+dev";
-          Test.test_dashdashversion "coclobas" "0.0.2-dev";
+          Test.test_dashdashversion "coclobas" "0.0.0";
+          Test.succeeds "ocamlfind list | grep coclobas | grep 0.0.2-dev";
         ];
       make "secotrec-default" ~dockerfile:(secotrec ())
         ~description:"OCaml/Opam environment with the `master` version of \

--- a/src/app/make_dockerfiles.ml
+++ b/src/app/make_dockerfiles.ml
@@ -203,6 +203,7 @@ module Dockerfiles = struct
       or_empty with_gcloudnfs install_gcloudnfs;
       or_empty with_secotrec_gke secotrec_gke_stuff;
       begin match coclobas with
+      | `Version v -> opam_pins ["coclobas", v]
       | `Branch b -> opam_pins [github_pin "coclobas" b]
       end;
     ]
@@ -317,14 +318,29 @@ module Image = struct
       make "coclobas-gke-dev"
         ~dockerfile:(coclobas ~with_gcloud:true ~ketrew:(`Branch "master")
                        ~coclobas:(`Branch "master") ());
+      make "coclobas-gke-biokepi-default"
+        ~description:"The default image used by Secotrec for GKE/Local \
+                      deployments, it has `gcloud`, `gcloudnfs`, the Biokepi \
+                      NFS-friendly user, TLS-tunnel, Coclobas 0.0.1 and \
+                      Ketrew `master` branch (until next version)."
+        ~dockerfile:(coclobas ~with_gcloud:true ~with_gcloudnfs:true
+                       ~with_biokepi_user:true ~with_secotrec_gke:true
+                       ~ketrew:(`Branch "master")
+                       ~coclobas:(`Version "0.0.1") ())
+        ~tests:[
+          Test.test_dashdashversion "ketrew" "3.0.0+dev";
+          Test.test_dashdashversion "coclobas" "0.0.1";
+        ];
       make "coclobas-gke-biokepi-dev"
+        ~description:"Image similar to `coclobas-gke-biokepi-default` but \
+                      with Coclobas pinned to its `master` branch."
         ~dockerfile:(coclobas ~with_gcloud:true ~with_gcloudnfs:true
                        ~with_biokepi_user:true ~with_secotrec_gke:true
                        ~ketrew:(`Branch "master")
                        ~coclobas:(`Branch "master") ())
         ~tests:[
           Test.test_dashdashversion "ketrew" "3.0.0+dev";
-          Test.test_dashdashversion "coclobas" "0.0.0";
+          Test.test_dashdashversion "coclobas" "0.0.2-dev";
         ];
       make "secotrec-default" ~dockerfile:(secotrec ())
         ~description:"OCaml/Opam environment with the `master` version of \

--- a/src/lib/coclobas.ml
+++ b/src/lib/coclobas.ml
@@ -7,7 +7,7 @@ type t = {
   port: int [@default 8082];
   tmp_dir: string [@default "/tmp/coclosecolocal"];
   db:Uri.t;
-  image: string [@default "hammerlab/keredofi:coclobas-gke-biokepi-dev"];
+  image: string [@default "hammerlab/keredofi:coclobas-gke-biokepi-default"];
   cluster: 
     [ `GKE of Gke_cluster.t | `Local of int ] [@main ];
 } [@@deriving make]

--- a/src/lib/deployment.ml
+++ b/src/lib/deployment.ml
@@ -295,7 +295,7 @@ module Run = struct
           :: List.map t.extra_nfs_servers ~f:(fun nfs ->
               exec [ (* We use the `gcoudnfs` script in the coclobas container *)
                 "sudo"; "docker"; "run";
-                "hammerlab/keredofi:coclobas-gke-biokepi-dev";
+                "hammerlab/keredofi:coclobas-gke-biokepi-default";
                 "sh"; "-c";
                 genspio_to_one_liner ~name:"ensure-nfs"
                   (Nfs.Fresh.ensure nfs.Extra_nfs_server.server);
@@ -400,7 +400,7 @@ module Run = struct
                   ~t:[
                     exec [
                       "sudo"; "docker"; "run";
-                      "hammerlab/keredofi:coclobas-gke-biokepi-dev";
+                      "hammerlab/keredofi:coclobas-gke-biokepi-default";
                       "sh"; "-c";
                       genspio_to_one_liner ~name:"destroy-nfs"
                         (Nfs.Fresh.destroy enfs);

--- a/src/lib/ketrew_server.ml
+++ b/src/lib/ketrew_server.ml
@@ -5,7 +5,7 @@ open Common
 type t = {
   auth_token: string;
   db: Postgres.t;
-  image: string [@default "hammerlab/keredofi:coclobas-gke-biokepi-dev"];
+  image: string [@default "hammerlab/keredofi:coclobas-gke-biokepi-default"];
   nfs_mounts: Nfs.Mount.t list;
   port: int [@default 8080 ];
   local_volumes: (string * string) list;

--- a/src/lib/tlstunnel.ml
+++ b/src/lib/tlstunnel.ml
@@ -1,7 +1,7 @@
 open Common
 
 type t = {
-  image: string [@default "hammerlab/keredofi:coclobas-gke-biokepi-dev"];
+  image: string [@default "hammerlab/keredofi:coclobas-gke-biokepi-default"];
   backend_address: string option;
   backend_port: int;
   frontend_address: string option;


### PR DESCRIPTION

After https://github.com/hammerlab/coclobas/pull/98 is merged, the `coclobas --version` test will have to be changed.

