### PR TITLE
Fix the PATH to the gcloud-sdk within test-biokepi-machine

### DIFF
--- a/src/lib/biokepi_machine_generation.ml
+++ b/src/lib/biokepi_machine_generation.ml
@@ -103,8 +103,8 @@ let biokepi_machine =
       && cmd "groups"
       && cmd "hostname"
       && cmd "uname -a"
-      && cmd "export PATH=/home/opam/google-cloud-sdk/bin:$PATH"
-      && cmd "ls /home/opam/google-cloud-sdk/bin"
+      && cmd "export PATH=$HOME/google-cloud-sdk/bin:$PATH"
+      && cmd "ls $HOME/google-cloud-sdk/bin"
       && prog
     in
   |ocaml}


### PR DESCRIPTION
The PATH was assuming that the user was `opam` instead of `biokepi`, so was getting this:

```
### Job ffbcf4e3-764a-5aea-8c6e-31d173d99d88
### Freshness: Fresh
### Output:

## Biokepi machine: 'umask 000'
## Biokepi machine: 'whoami'
biokepi
## Biokepi machine: 'groups'
biokepi
## Biokepi machine: 'hostname'
ffbcf4e3-764a-5aea-8c6e-31d173d99d88
## Biokepi machine: 'uname -a'
Linux ffbcf4e3-764a-5aea-8c6e-31d173d99d88 3.16.0-4-amd64 #1 SMP Debian 3.16.39-1 (2016-12-30) x86_64 x86_64 x86_64 GNU/Linux
## Biokepi machine: 'export PATH=/home/opam/google-cloud-sdk/bin:/home/biokepi/google-cloud-sdk/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
## Biokepi machine: 'ls /home/opam/google-cloud-sdk/bin'
ls: cannot access '/home/opam/google-cloud-sdk/bin': No such file or directory
Command failed
344M	/home/biokepi
```

this change fixes the issue:

```
### Job 5a882a3b-5197-5e30-b13e-3242e71f2807
### Freshness: Fresh
### Output:

## Biokepi machine: 'umask 000'
## Biokepi machine: 'whoami'
biokepi
## Biokepi machine: 'groups'
biokepi
## Biokepi machine: 'hostname'
5a882a3b-5197-5e30-b13e-3242e71f2807
## Biokepi machine: 'uname -a'
Linux 5a882a3b-5197-5e30-b13e-3242e71f2807 3.16.0-4-amd64 #1 SMP Debian 3.16.39-1 (2016-12-30) x86_64 x86_64 x86_64 GNU/Linux
## Biokepi machine: 'export PATH=/home/biokepi/google-cloud-sdk/bin:/home/biokepi/google-cloud-sdk/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
## Biokepi machine: 'ls /home/biokepi/google-cloud-sdk/bin'
bootstrapping
bq
dev_appserver.py
endpointscfg.py
gcloud
git-credential-gcloud.sh
gsutil
kubectl
344M	/home/biokepi
```