### PR TITLE
Install gcloud-sdk under /opt instead of $HOME

### DIFF
--- a/src/app/make_dockerfiles.ml
+++ b/src/app/make_dockerfiles.ml
@@ -128,8 +128,9 @@ module Dockerfiles = struct
     comment "Installing GCloud command-line tool with kubectl" @@@ [
       apt_get_install ["python"; "build-essential"];
       env ["CLOUDSDK_CORE_DISABLE_PROMPTS", "true"];
+      env ["CLOUDSDK_INSTALL_DIR", "/opt"];
       bash_c ~sudo:false "curl https://sdk.cloud.google.com | bash";
-      env ["PATH", "${HOME}/google-cloud-sdk/bin/:${PATH}"];
+      env ["PATH", "${CLOUDSDK_INSTALL_DIR}/google-cloud-sdk/bin/:${PATH}"];
       run "gcloud components install kubectl";
     ]
 

--- a/src/lib/biokepi_machine_generation.ml
+++ b/src/lib/biokepi_machine_generation.ml
@@ -103,8 +103,8 @@ let biokepi_machine =
       && cmd "groups"
       && cmd "hostname"
       && cmd "uname -a"
-      && cmd "export PATH=$HOME/google-cloud-sdk/bin:$PATH"
-      && cmd "ls $HOME/google-cloud-sdk/bin"
+      && cmd "export PATH=/opt/google-cloud-sdk/bin:$PATH"
+      && cmd "ls /opt/google-cloud-sdk/bin"
       && prog
     in
   |ocaml}

--- a/src/lib/coclobas.ml
+++ b/src/lib/coclobas.ml
@@ -46,7 +46,7 @@ let to_service t =
           (string_concat [
               getenv (string "PATH");
               string ":";
-              string "/home/opam/google-cloud-sdk/bin/";
+              string "/opt/google-cloud-sdk/bin/";
             ]);
         exec ["sh"; "-c"; "echo \"PATH: $PATH\""];
         exec ["gcloud"; "--version"];

--- a/src/lib/nfs.ml
+++ b/src/lib/nfs.ml
@@ -92,7 +92,7 @@ module Fresh = struct
       ensure
         ~name:(sprintf "NFS-%s-is-up" t.name)
         (Gcloud_instance.instance_is_up
-           ~gcloud:"/home/opam/google-cloud-sdk/bin/gcloud"
+           ~gcloud:"/opt/google-cloud-sdk/bin/gcloud"
            t.instance)
         [
           seq_succeeds_or ~name:(sprintf "Creating-NFS-%s" t.name)
@@ -121,7 +121,7 @@ module Fresh = struct
         ~name:(sprintf "Waiting-for-NFS-%s-to-be-up" t.name)
         ~clean_up:[fail] [
         loop_until_ok
-          (exec ["/home/opam/google-cloud-sdk/bin/gcloud"; "compute"; "ssh"; vm_name t;
+          (exec ["/opt/google-cloud-sdk/bin/gcloud"; "compute"; "ssh"; vm_name t;
                  "--zone"; t.instance.Gcloud_instance.zone;
                  "--command"; sprintf "ls %s/" (storage_path t)]
            |> succeeds_silently)
@@ -129,13 +129,13 @@ module Fresh = struct
           ~sleep:5;
       ];
       ensure ~name:(sprintf "NFS-%s-witness" t.name)
-        (exec ["/home/opam/google-cloud-sdk/bin/gcloud"; "compute"; "ssh"; vm_name t;
+        (exec ["/opt/google-cloud-sdk/bin/gcloud"; "compute"; "ssh"; vm_name t;
                "--zone"; t.instance.Gcloud_instance.zone;
                "--command"; sprintf "ls %s" (witness_path t)]
          |> succeeds_silently) [
         seq_succeeds_or ~name:(sprintf "Creating-NFS-%s-witness" t.name)
           ~clean_up:[fail] [
-          exec ["/home/opam/google-cloud-sdk/bin/gcloud"; "compute"; "ssh"; vm_name t;
+          exec ["/opt/google-cloud-sdk/bin/gcloud"; "compute"; "ssh"; vm_name t;
                 "--zone"; t.instance.Gcloud_instance.zone;
                 "--command"; sprintf "echo hello > %s" (witness_path t)];
         ]


### PR DESCRIPTION
Also relevant to this: #30

Currently, It is a bit hard to keep track of which image assumes which user and hence where the gcloud utils get installed. I had this issue while thinking about a workflow product that makes use of `gsutil` and realized that `hammerlab/keredofi:coclobas-gke-biokepi-default` had gcloud utils installed only for the `opam` user and ketrew was running as the `biokepi`. Since it would be ugly to try to call the utils from a different user's directory, I thought changing the path for the gcloud-sdk installation will give us some uniformity across images and apps.

This is, of course, open to comments and other suggestions.