### PR TITLE
secotrec-gke: fix typo in subcommand (varirables -> variables)

### DIFF
--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -180,7 +180,7 @@ let deployment_commands (deployment : unit -> Deployment.t) =
         ) in
   let useful_env =
     sub_command
-      ~info:Term.(info "environment-varirables"
+      ~info:Term.(info "environment-variables"
                     ~version ~sdocs:"COMMON OPTIONS" ~man:[]
                     ~doc:"Generate some useful environment variables.")
       ~term: Term.(


### PR DESCRIPTION
I was trying to run this manually and was wondering why it was not working although I made sure I was typing the command and then realized that extra `r` is to blame. Phew.