### PR TITLE
Update NetMHC configuration handling to sync with Biokepi

### DIFF
--- a/src/app/example_gke.ml
+++ b/src/app/example_gke.ml
@@ -96,6 +96,13 @@ let configuration =
           annoying_url "NETMHCPAN_TARBALL_URL" "netMHCpan-2.8a.Linux.tar.gz" "NetMHCPan";
           annoying_url "PICKPOCKET_TARBALL_URL" "pickpocket-1.1a.Linux.tar.gz" "PickPocket";
           annoying_url "NETMHCCONS_TARBALL_URL" "netMHCcons-1.1a.Linux.tar.gz" "NetMHCCons";
+          env "NETMHC_TMPDIR"
+            ~help:"Where the NetMHC-family of tools should store their \n\
+                   temporary files on the pod. Note that these tools can \n\
+                   misbehave and arbitrarily drop some predictions if you \n\
+                   use a path to a folder on a mounted device."
+            ~default:"/tmp/"
+            ~example:"/path/to/tmp/";
         ]
       end;
   ]

--- a/src/lib/biokepi_machine_generation.ml
+++ b/src/lib/biokepi_machine_generation.ml
@@ -44,14 +44,20 @@ let image =
 let env_exn_tool_loc s tool =
   try (`Wget (Sys.getenv s)) with _ ->
     `Fail (sprintf "No location provided for %s" tool)
+let netmhc_tmpdir =
+  try env_exn "NETMHC_TMPDIR"
+  with _ -> "/tmp" (* local to each worker pod *)
+let netmhc_config () = Biokepi.Setup.Netmhc.(
+  create_netmhc_config
+    ~netmhc_tmpdir
+    ~netmhc_loc:(env_exn_tool_loc "NETMHC_TARBALL_URL" "NetMHC")
+    ~netmhcpan_loc:(env_exn_tool_loc "NETMHCPAN_TARBALL_URL" "NetMHCpan")
+    ~pickpocket_loc:(env_exn_tool_loc "PICKPOCKET_TARBALL_URL" "PickPocket")
+    ~netmhccons_loc:(env_exn_tool_loc "NETMHCCONS_TARBALL_URL" "NetMHCcons")
+    ()
+)
 let gatk_jar_location () = env_exn_tool_loc "GATK_JAR_URL" "GATK"
 let mutect_jar_location () = env_exn_tool_loc "MUTECT_JAR_URL" "MuTect"
-let netmhc_tool_locations () = Biokepi.Setup.Netmhc.({
-  netmhc=env_exn_tool_loc "NETMHC_TARBALL_URL" "NetMHC";
-  netmhcpan=env_exn_tool_loc "NETMHCPAN_TARBALL_URL" "NetMHCpan";
-  pickpocket=env_exn_tool_loc "PICKPOCKET_TARBALL_URL" "PickPocket";
-  netmhccons=env_exn_tool_loc "NETMHCCONS_TARBALL_URL" "NetMHCcons";
-})
 |ocaml}
 
 let set_name name = {ocaml|
@@ -119,7 +125,7 @@ let biokepi_machine =
       ~run_program
       ~gatk_jar_location
       ~mutect_jar_location
-      ~netmhc_tool_locations in
+      ~netmhc_config in
   Biokepi.Machine.create name
     ~pyensembl_cache_dir
     ~max_processors


### PR DESCRIPTION
Follows up on https://github.com/hammerlab/biokepi/pull/465 and allows customizing the temporary directory that the NetMHC tools will be using via an environment variable. Also updates the `biokepi_machine` to match with the new signature.

With this change, secotrec-generated `env` file now has documentation and warning on potential issues with setting a mounted dir as the temporary dir (cf. https://github.com/hammerlab/biokepi/issues/467):

```
$ secotrec-gke genconf example.env
$ tail -8 example.env
# ### Variable `NETMHC_TMPDIR` (optional, default: /tmp/):
# 
#     export NETMHC_TMPDIR=/path/to/tmp/
# 
# Where the NetMHC-family of tools should store their 
# their temporary files on the pod. Note that NetMHC tools can 
# misbehave if you use a folder on one of the mounted folders.
```

cc: @julia326 